### PR TITLE
Compute patch result at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/
 
+## Unreleased
+### Changed
+* `el-patch` now computes the patched definition and generates the
+code to register and apply it at compile time, therefore incurring
+less runtime overhead.
+
 ## 1.2 (released 2017-07-23)
 ### Added
 * `el-patch` now has a Makefile for convenient byte-compilation,

--- a/README.md
+++ b/README.md
@@ -464,6 +464,18 @@ el-patch-validate` and `M-x el-patch-ediff-conflict`.
 When you call `M-x el-patch-unpatch`, the patch definition is resolved
 again and the original version is installed by evaluating it.
 
+## `el-patch` is not needed at runtime
+
+El-patch computes the patched definition and generates the code to
+register and apply it at compile time. Therefore, `el-patch` need not be loaded at runtime.
+This means you can write:
+
+    (eval-when-compile
+      (require 'el-patch))
+    (defvar el-patch--patches (make-hash-table))
+
+And `el-patch` will not be loaded on init!
+
 ## But does it actually work?
 
 It doesn't seem to crash [my Emacs][radian], at least.

--- a/el-patch.el
+++ b/el-patch.el
@@ -80,6 +80,7 @@ be installed before the features can be loaded."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; Internal variables
 
+;;;###autoload
 (defvar el-patch--patches (make-hash-table :test 'equal)
   "Hash table of patches that have been defined.
 The keys are symbols naming the objects that have been patched.

--- a/el-patch.el
+++ b/el-patch.el
@@ -462,7 +462,9 @@ DEFINITION should be a list beginning with `defun', `defmacro',
            ;; complains about it.
            (list `(makunbound ,(cadr definition))))
        ,definition
-       ,@(cl-loop for item in items collect `(setq current-load-list (remove ',item current-load-list))))))
+       ,@(cl-loop for item in items collect
+                  `(setq current-load-list
+                         (remove ',item current-load-list))))))
 
 (defmacro el-patch--definition (patch-definition)
   "Activate a PATCH-DEFINITION and update `el-patch--patches'.
@@ -745,8 +747,8 @@ This restores the original functionality of the object being
 patched. NAME and TYPE are as returned by `el-patch-get'."
   (interactive (el-patch--select-patch))
   (if-let ((patch-definition (el-patch-get name type)))
-      (el-patch--stealthy-eval (el-patch--resolve-definition
-                                patch-definition nil))
+      (eval `(el-patch--stealthy-eval ,(el-patch--resolve-definition
+                                        patch-definition nil)))
     (error "There is no patch for %S %S" type name)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This should move the patch computation to compile time, allowing the byte compiler to optimize the function definitions ahead of time. It also means that `el-patch` need not be loaded at runtime, unless the user would like to interact with the patches using `el-patch`'s UI.

I'm currently running this, but it may take some work to get it into a mergable state.