### PR TITLE
el-patch-template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### New features
+* New way to patch elisp objects based on a partial template and the
+  original definition the object ([#50]).
+
 ### Bugs fixed
 * Patch forms were not processed when they appeared inside a vector.
   This has been fixed ([#51]).
 
+[#50]: https://github.com/raxod502/el-patch/issues/50
 [#51]: https://github.com/raxod502/el-patch/issues/51
 
 ## 2.3.1 (released 2020-07-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### New features
 * New way to patch elisp objects based on a partial template and the
-  original definition the object ([#50]).
+  original definition the object ([#50]). See the documentation on
+  `el-patch-template` in the README.
 
 ### Bugs fixed
 * Patch forms were not processed when they appeared inside a vector.

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ checkindent: ## Ensure that indentation is correct
 	    emacs -Q --batch \
 	        --eval "(setq inhibit-message t)" \
 	        --eval "(load (expand-file-name \"el-patch.el\") nil t)" \
-		--eval "(find-file \"$$file\")" \
+	        --eval "(find-file \"$$file\")" \
 	        --eval "(indent-region (point-min) (point-max))" \
 	        --eval "(write-file \"$$tmpdir/$$file\")"; \
 	    (diff <(cat          "$$file" | nl -v1 -ba | \

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SHELL := bash
 EMACS ?= emacs
 
 # The order is important for compilation.
-for_compile := el-patch.el
-for_checkdoc := el-patch.el
+for_compile := el-patch.el el-patch-template.el
+for_checkdoc := el-patch.el el-patch-template.el
 for_longlines := $(wildcard *.el *.md *.yml) Makefile
 for_checkindent := $(wildcard *.el)
 
@@ -62,7 +62,7 @@ checkindent: ## Ensure that indentation is correct
 	    emacs -Q --batch \
 	        --eval "(setq inhibit-message t)" \
 	        --eval "(load (expand-file-name \"el-patch.el\") nil t)" \
-	        --eval "(find-file \"$$file\")" \
+		--eval "(find-file \"$$file\")" \
 	        --eval "(indent-region (point-min) (point-max))" \
 	        --eval "(write-file \"$$tmpdir/$$file\")"; \
 	    (diff <(cat          "$$file" | nl -v1 -ba | \

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ keyword, then a call to `el-patch-feature` is inserted into the
 
 ## Templates
 
-In some cases, you may want to patch on or two forms in a long
+In some cases, you may want to patch one or two forms in a long
 definition of a function or a macro. Defining the patch would still
 require copying all unpatched forms and updating the patch when these
 forms change. For these cases, it would be better if we can simply
@@ -582,7 +582,7 @@ Had we wanted to simply patch the function we would pass `(defun
 restart-emacs)` as the first argument. Every other argument defines a
 template for a patch. To build the final patch, every argument is
 resolved to figure out the original form which is then matched against
-all forms in the original definition of the object, and if uniquely
+all forms in the original definition of the object and, if uniquely
 found, the patch is spliced in its place. The special form `...` is
 used to match one or more forms or, if it is inside `el-patch-concat`
 as above, one or more characters in a string. Patch templates need not

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Lazy-loading packages](#lazy-loading-packages)
 - [Validating patches that are not loaded yet](#validating-patches-that-are-not-loaded-yet)
 - [Integration with `use-package`](#integration-with-use-package)
+- [Templates](#templates)
 - [Usage with byte-compiled init-file](#usage-with-byte-compiled-init-file)
 - [But how does it work?](#but-how-does-it-work)
 - [But how does it actually work?](#but-how-does-it-actually-work)
@@ -541,6 +542,72 @@ macro are left as is.) The resulting code is prepended to the code in
 keyword, then a call to `el-patch-feature` is inserted into the
 `:init` section.
 
+## Templates
+
+In some cases, you may want to patch on or two forms in a long
+definition of a function or a macro. Defining the patch would still
+require copying all unpatched forms and updating the patch when these
+forms change. For these cases, it would be better if we can simply
+search for the forms that we want to patch in the original definition
+and patch only those. Enter `el-patch` templates.
+
+As an example, say we want to define a patch of `restart-emacs` so
+that the it starts a new emacs instance without killing the current
+one. Instead of defining a patch that includes the complete definition
+of `restart-emacs`, we can define a template as follows
+
+    (el-patch-define-template
+      (defun (el-patch-swap restart-emacs radian-new-emacs))
+      (el-patch-concat
+        (el-patch-swap
+          "Restart Emacs."
+          "Start a new Emacs session without killing the current one.")
+        ...
+        (el-patch-swap "restarted" "started")
+        ...
+        (el-patch-swap "restarted" "started")
+        ...
+        (el-patch-swap "restarted" "started")
+        ...)
+      (restart-args ...)
+      (el-patch-remove (kill-emacs-hook ...))
+      (el-patch-swap
+        (save-buffers-kill-emacs)
+        (restart-emacs--launch-other-emacs restart-args)))
+
+The first argument is a list that comprises the type, `defun` in this
+case, and the name of the object that we are patching. Using an
+`el-patch-swap` here allows us to define a fork, `radian-new-emacs`.
+Had we wanted to simply patch the function we would pass `(defun
+restart-emacs)` as the first argument. Every other argument defines a
+template for a patch. To build the final patch, every argument is
+resolved to figure out the original form which is then matched against
+all forms in the original definition of the object, and if uniquely
+found, the patch is spliced in its place. The special form `...` is
+used to match one or more forms or, if it is inside `el-patch-concat`
+as above, one or more characters in a string. Patch templates need not
+be, or even contain, `el-patch-*` directives. For example, the purpose
+of the argument `(restart-args ...)` is to make sure that such a form
+exists in the function definition without actually patching it.
+
+After defining the template, you can call `el-patch-insert-template`
+to insert the patch definition in the current buffer based on the
+defined template. Alternatively, you may call `el-patch-eval-template`
+which directly evaluates the patch. The function
+`el-patch-define-and-eval-template` defines and evaluates a template
+in one go. It is recommended that you compile your init-file if you
+use `el-patch-define-and-eval-template` to avoid the overhead of
+template matching when starting Emacs. `el-patch` will issue a warning
+if `el-patch-define-and-eval-template` is called at runtime and
+`el-patch-warn-on-eval-template` is non-nil (which is the default).
+
+Templates assume that the original definition of the object is
+accessible, for example, using `find-function-noselect` for functions.
+
+Like patches, templates can be validated using
+`el-patch-validate-template` and `el-patch-validate-all-templates`.
+
+
 ## Usage with byte-compiled init-file
 
 `el-patch` does not need to be loaded at runtime just to define
@@ -562,7 +629,7 @@ Magic.
 
 The basic idea is simple. When a patch is defined, the patch
 definition is resolved to figure out the modified definition is. Then
-that definition is installed by evaluating it (but using
+that definition is installed by evaluating it (by using
 `el-patch--stealthy-eval`, so that looking up the function definition
 will return the original location rather than the `el-patch`
 invocation location, and also using `makunbound` to override a

--- a/README.md
+++ b/README.md
@@ -590,16 +590,17 @@ be, or even contain, `el-patch-*` directives. For example, the purpose
 of the argument `(restart-args ...)` is to make sure that such a form
 exists in the function definition without actually patching it.
 
-After defining the template, you can call `el-patch-insert-template`
-to insert the patch definition in the current buffer based on the
-defined template. Alternatively, you may call `el-patch-eval-template`
-which directly evaluates the patch. The function
-`el-patch-define-and-eval-template` defines and evaluates a template
-in one go. It is recommended that you compile your init-file if you
-use `el-patch-define-and-eval-template` to avoid the overhead of
-template matching when starting Emacs. `el-patch` will issue a warning
-if `el-patch-define-and-eval-template` is called at runtime and
-`el-patch-warn-on-eval-template` is non-nil (which is the default).
+After defining the template, you can run the interactive command
+`el-patch-insert-template` to insert the patch definition in the
+current buffer based on the defined template. Alternatively, you may
+use the command `el-patch-eval-template` which directly evaluates the
+patch. The function `el-patch-define-and-eval-template` defines and
+evaluates a template in one go. It is recommended that you compile
+your init-file if you use `el-patch-define-and-eval-template` to avoid
+the overhead of template matching when starting Emacs. `el-patch` will
+issue a warning if `el-patch-define-and-eval-template` is called at
+runtime and `el-patch-warn-on-eval-template` is non-nil (which is the
+default).
 
 Templates assume that the original definition of the object is
 accessible, for example, using `find-function-noselect` for functions.

--- a/el-patch-template.el
+++ b/el-patch-template.el
@@ -1,0 +1,500 @@
+;;; el-patch-template.el --- -*- lexical-binding: t -*-
+
+
+;; Author: Al Haji-Ali <abdo.haji.ali@gmail.com>
+;; Created: 1 March 2021
+;; Homepage: http://www.randomoid.com
+;; Keywords: extensions
+;; Package-Requires: ((emacs "25"))
+;; SPDX-License-Identifier: MIT
+;; Version: 0.0.1
+
+;;; Commentary:
+
+;; `el-patch-template' is an extension of `el-patch' that allows one
+;; to specifiy a patch without providing the complete source code of
+;; the patched form.
+;;
+;; Example usage:
+;;
+;; (el-patch-template (defun TeX-update-style)
+;;   (el-patch-concat
+;;     "Run style specific hooks"
+;;     (el-patch-add
+;;       ", silently,")
+;;     " for the current document.
+;;
+;; Only do this if it has not been done before, or if optional argument
+;; FORCE is not nil.")
+;;   (el-patch-remove
+;;     (... "Applying style hooks..."))
+;;   (el-patch-remove
+;;     (... "Applying style hooks...done")))
+
+(defun el-patch-template--process-el-patch
+    (form template &optional match next-step-fn table)
+  "Processes an el-patch statement. Arguments are the same as
+`el-patch-template--match'. Assume thats template is a cons whose
+car is an el-patch directive and throws `not-el-patch' otherwise.
+Upon succesful matching calls `next-step-fn' with MATCH after
+appending it with the matching forms from FORM."
+  (when (consp template)
+    (let* ((directive (car template)))
+      (pcase directive
+        ('el-patch-swap
+          (let ((swap-next-step
+                 (lambda (new-match remainder-form)
+                   (when (cdr new-match)
+                     ;; el-patch-swap swaps a single form
+                     ;; with another
+                     (throw 'no-match nil))
+                   (funcall next-step-fn
+                            (append match
+                                    (list
+                                     (list directive
+                                           ;; First argument is
+                                           ;; replaced by match
+                                           (car new-match)
+                                           ;; Second argument as is
+                                           ;; from template
+                                           (caddr template))))
+                            remainder-form))))
+            (el-patch-template--process form
+                                        ;; We match the first argument
+                                        ;; only
+                                        (list (cadr template))
+                                        nil swap-next-step
+                                        table nil)))
+        ((or 'el-patch-wrap 'el-patch-splice)
+         (let* ((triml (if (>= (length template) 3)
+                           (nth 1 template)
+                         0))
+                (trimr (if (>= (length template) 4)
+                           (nth 2 template)
+                         0))
+                (is-splice (equal directive 'el-patch-splice))
+                (body (car (last template)))
+                (wrap-next-step
+                 (lambda (new-match remainder-form)
+                   (funcall next-step-fn
+                            (append match
+                                    ;; The directive with arguments
+                                    (list (append
+                                           (cl-subseq template 0
+                                                      (1- (length template)))
+                                           (if (equal directive
+                                                      'el-patch-splice)
+                                               new-match
+                                             (list (append
+                                                    (cl-subseq body 0 triml)
+                                                    (car new-match)
+                                                    (last body trimr)))))))
+                            remainder-form))))
+           (el-patch-template--process form
+                                       (list
+                                        (if is-splice
+                                            body
+                                          ;; Should not match the trimmings
+                                          (nthcdr triml (butlast body trimr))))
+                                       nil
+                                       wrap-next-step
+                                       table
+                                       nil)))
+        ((quote el-patch-let)
+         (let* ((bindings (nth 1 template))
+                (body (nthcdr 2 template))
+                (let-next-step (lambda (new-match remainder-form)
+                                 ;; Build list of new bindings
+                                 ;; based on the their resolution
+                                 (let ((new-bindings
+                                        (mapcar
+                                         (lambda (kv)
+                                           (let ((x (gethash (car kv)
+                                                             table)))
+                                             (list (car kv)
+                                                   (or (cdr x) (car x)))))
+                                         bindings)))
+                                   (funcall next-step-fn
+                                            (append match
+                                                    (list
+                                                     (append
+                                                      (list
+                                                       directive
+                                                       new-bindings)
+                                                      new-match)))
+                                            remainder-form)))))
+           (el-patch--with-puthash table
+               (mapcar
+                (lambda (kv)
+                  (unless (symbolp (car kv))
+                    (error "Non-symbol (%s) as binding for `el-patch-let'"
+                           (car kv)))
+                  (list (car kv)
+                        (cons (cadr kv)
+                              ;; The cdr is the resolution, nil for
+                              ;; now, and will be filled in
+                              ;; el-patch-template--match
+                              nil)))
+                bindings)
+             (el-patch-template--process form body
+                                         nil
+                                         let-next-step
+                                         table))))
+        ('el-patch-concat
+          (when (or (not (consp form))
+                    (not (stringp (car form))))
+            ;; el-patch-concat can only match a string
+            (throw 'not-el-patch nil))
+          (let* ((resolved (car (el-patch--resolve (cdr template) nil)))
+                 (regex
+                  (apply 'concat (mapcar (lambda (x)
+                                           (if (equal x '...)
+                                               ;;"[\0-\377[:nonascii:]]*"
+                                               ;; match any
+                                               ;; character
+                                               "\\(\\(?:.\\|\n\\)*\\)"
+                                             (regexp-quote x)))
+                                         resolved)))
+                 (match-no 1) split-form)
+            (save-match-data
+              (unless (string-match (concat "^" regex "$") (car form))
+                (throw 'not-el-patch nil))
+              ;; Exchange form by the resolved template splicing in
+              ;; the matched strings
+              (setq split-form
+                    (mapcar (lambda (x)
+                              (if (equal x '...)
+                                  (prog1
+                                      (match-string match-no
+                                                    (car form))
+                                    (setq match-no
+                                          (1+ match-no)))
+                                x))
+                            resolved)))
+            (el-patch-template--process split-form
+                                        (cdr template)
+                                        nil
+                                        (lambda (new-match
+                                                 remainder-form)
+                                          (when remainder-form
+                                            ;; Must be a complete
+                                            ;; match
+                                            (throw 'not-el-patch
+                                                   nil))
+                                          (funcall next-step-fn
+                                                   (append match
+                                                           (list (cons
+                                                                  directive
+                                                                  new-match)))
+                                                   (cdr form)))
+                                        table)))
+        ((or 'el-patch-literal 'el-patch-remove 'el-patch-concat)
+         (el-patch-template--process form (cdr template)
+                                     nil
+                                     (lambda (new-match remainder-form)
+                                       (funcall next-step-fn
+                                                (append match
+                                                        (list (cons
+                                                               directive
+                                                               new-match)))
+                                                remainder-form))
+                                     table
+                                     (equal directive 'el-patch-literal)))
+        ('el-patch-add ;; Matches nothing
+          (funcall next-step-fn
+                   ;; simply add the template to the match
+                   (append match (list template))
+                   form))
+        (_
+         (throw 'not-el-patch nil))))))
+
+(defun el-patch-template--process (form template &optional match
+                                        next-step-fn
+                                        table literal)
+  "Matches TEMPLATE to FORM. TEMPLATE may contain `...' which
+greedily match any number of form. It may also contain
+`el-patch-*' directives which are resolved before matching. Match
+is succesfful if FORM matches TEMPLATE. Return value is a cons
+where the car is the forms from FROM which match TEMPLATE the cdr
+are the are the remaining unmatched forms. If TEMPLATE is nil,
+calls NEXT-STEP-FN with MATCH and FORM. When LITERAL is non-nil,
+do not process el-patch-* directives. TABLE is a hash-table which
+contains bindings used by `el-patch-let'"
+  (let ((next-step-fn (or next-step-fn
+                          (lambda (match remainder-form)
+                            ;; Simply return
+                            (cons match remainder-form))))
+        (table (or table (make-hash-table :test 'equal))))
+    (cond
+     ((and (not literal)
+           (consp template)
+           (consp (car template))
+           (member (caar template) '(el-patch-swap el-patch-wrap
+                                                   el-patch-splice
+                                                   el-patch-remove
+                                                   el-patch-add
+                                                   el-patch-concat
+                                                   el-patch-let)))
+      (el-patch-template--process-el-patch form (car template)
+                                           match
+                                           ;; The next step is to
+                                           ;; match cdr template
+                                           (lambda (new-match remainder-form)
+                                             (el-patch-template--process
+                                              remainder-form
+                                              (cdr template)
+                                              new-match
+                                              next-step-fn
+                                              table literal))
+                                           table))
+     ((and (consp template) (consp form))
+      (if (member (car template) '(...))
+          ;; TODO: Need to check the if we are in a string here and if
+          ;; so do something special? -- If we are in a string, we
+          ;; have to assume that form has a single string element and
+          ;; we deal with it. If it is not the case, then this cannot
+          ;; be a match
+          (progn
+            (let ((dots-next-step
+                   (lambda (new-match remainder-form)
+                     (funcall next-step-fn
+                              (append match
+                                      (cons (car form)
+                                            new-match))
+                              remainder-form))))
+              (or
+               (catch 'no-match
+                 (el-patch-template--process (cdr form)
+                                             ;; Try not consuming `...'
+                                             template nil
+                                             dots-next-step table
+                                             literal))
+               (el-patch-template--process (cdr form)
+                                           ;; If we are here, we failed
+                                           ;; the previous match so try
+                                           ;; consuming `...'
+                                           (cdr template) nil
+                                           dots-next-step table
+                                           literal))))
+        ;; NOTE: If we want to match zero or more (rather than one
+        ;; or more) then we need to catch the except ion from the
+        ;; previous line and try matching after consuming `...'
+        ;; from TEMPLATE but not consuming any from FORM
+        (let ((consp-next-step (lambda (new-match remainder-form)
+                                 ;; If we are in a string and the
+                                 ;; remainder is a string then we can
+                                 ;; still match it
+                                 (el-patch-template--process
+                                  (if remainder-form
+                                      (cons remainder-form
+                                            (cdr form))
+                                    (cdr form))
+                                  (cdr template)
+                                  (append match ;; start with previous match
+                                          (list new-match))
+                                  next-step-fn
+                                  table literal))))
+          (el-patch-template--process (car form) (car template)
+                                      nil consp-next-step table
+                                      literal))))
+     ((null template) ;; nothing else to match
+      (funcall next-step-fn match form))
+     ((or (member template '(...)) (equal template form))
+      ;; A Complete match.
+      (funcall next-step-fn (append match form) nil))
+     (t
+      (or (when-let ((symbol (gethash template table))
+                     (symbol-next-step
+                      (lambda (new-match remainder-form)
+                        ;; First put the match in the table.
+                        (let ((old-entry (gethash template table)))
+                          (puthash template
+                                   (cons
+                                    (car symbol)
+                                    new-match)
+                                   table)
+                          ;; Then process the next step, adding the
+                          ;; template to the match
+                          (condition-case _
+                              (funcall next-step-fn
+                                       (if match
+                                           (cons match template)
+                                         template)
+                                       remainder-form)
+                            ('no-match
+                             ;; Ultimately, the matching did not
+                             ;; work, so undo the symbol resolution
+                             (puthash template old-entry table)
+                             ;; and rethrow
+                             (throw 'no-match nil)))))))
+            (el-patch-template--process form
+                                        (or
+                                         ;; The previous resolution
+                                         (cdr symbol)
+                                         ;; The template-value
+                                         (car symbol))
+                                        nil
+                                        symbol-next-step
+                                        table literal))
+          (throw 'no-match nil))))))
+
+(defun el-patch-template--match-p (form template)
+  "Matches TEMPLATE to FORM. TEMPLATE may contain `...' which
+greedily match any number of form. Match is succesful if a
+partial list of FORM, starting from the beginning matches
+TEMPLATE. The return value is the number of forms in FORM which
+match template or nil if a match is not possible."
+  (cond
+   ((and (consp template) (consp form))
+    (when-let ((matched-count
+                (if (member (car template) '(...))
+                    (or
+                     (el-patch-template--match-p (cdr form)
+                                                 template)
+                     ;; If we are here, we failed so try consuming
+                     ;; `...'
+                     (el-patch-template--match-p (cdr form)
+                                                 (cdr template)))
+                  (and
+                   (el-patch-template--match-p (car form)
+                                               (car template))
+                   (el-patch-template--match-p (cdr form)
+                                               (cdr template))))))
+      (1+ matched-count)))
+   ((and (consp template)
+         (equal (car template) 'el-patch-concat)
+         (stringp form))
+    (string-match-p
+     (apply 'concat (mapcar (lambda (x)
+                              (if (and (equal x '...))
+                                  ;; match any character
+                                  ;;"[\0-\377[:nonascii:]]*"
+                                  "\\(.\\|\n\\)*"
+                                (regexp-quote x)))
+                            (cdr template)))
+     form))
+   (t (or (and (null template) 0)
+          (and (or (member template '(...))
+                   (equal template form))
+               (if (consp form)
+                   (length form)
+                 1))))))
+
+(defun el-patch-template--any-p (definition ptemplates &optional up-to)
+  "Returns t if any templates in PTEMPLATE match any form in
+definition, otherwise returns nil."
+  (and (or (null up-to) (> up-to 0))
+       (or (cl-some
+            (lambda (x) (el-patch-template--match-p definition
+                                                    (plist-get x :old)))
+            ptemplates)
+           (and
+            (consp definition)
+            (or (el-patch-template--any-p (car definition)
+                                          ptemplates)
+                (el-patch-template--any-p (cdr definition)
+                                          ptemplates
+                                          (when up-to
+                                            (1- up-to))))))))
+
+(defun el-patch-template--apply (definition ptemplates)
+  "The actual implementation of `el-patch-template--apply'. Here,
+PTEMPLATE is a list of plist templates which contain `:template'
+where the actual template resides, `:old' is the template's old
+resolution and `:matched' which is set to t if the template is
+matched in DEFINITION."
+  (let (matched-forms-count matched-ptemplate)
+    (cl-dolist (ptemplate ptemplates)
+      (let ((matched (el-patch-template--match-p definition
+                                                 (plist-get ptemplate :old))))
+        (when matched
+          (when matched-ptemplate
+            (error "A form matches multiple templates"))
+          (setq matched-forms-count matched
+                matched-ptemplate ptemplate))))
+    (cond
+     ((null matched-ptemplate)
+      (if (consp definition)
+          (cons (el-patch-template--apply (car definition)
+                                          ptemplates)
+                (el-patch-template--apply (cdr definition)
+                                          ptemplates))
+        definition))
+     ((plist-get matched-ptemplate :matched)
+      (error "A template matches multiple forms"))
+     ((and (consp definition)
+           (or
+            (el-patch-template--any-p (car definition)
+                                      ptemplates)
+            (and
+             (cdr definition)
+             (el-patch-template--any-p (cdr definition)
+                                       ptemplates
+                                       (1- matched-forms-count)))))
+      (error "A form matching a template has subforms matching\
+ other templates"))
+     (t
+      ;; The old resolution of the template uniquely matches the definition
+      ;; Here we first mark the template as being matched then
+      ;; do the actual resolution
+      (plist-put matched-ptemplate :matched t)
+      (let ((resolution
+             (el-patch-template--process definition
+                                         (list
+                                          (plist-get matched-ptemplate
+                                                     :template)))))
+        (cons (caar resolution)
+              (el-patch-template--apply (cdr resolution)
+                                        ptemplates)))))))
+
+(defun el-patch-template--resolve (forms)
+  "Calls `el-patch--resolve' with a special treatment for
+`el-patch-concat'. Specifically, if the arguments of
+`el-patch-concat' have `...' in them, it is not resolved."
+  (cl-letf* ((old-concat (symbol-function 'concat))
+             ((symbol-function 'concat)
+              (lambda (&rest args)
+                (if (cl-some (lambda (x) (equal x '...)) args)
+                    (append '(el-patch-concat) args)
+                  (apply old-concat args)))))
+    (el-patch--resolve forms nil)))
+
+(defun el-patch-template--impl (keyword-name templates)
+  "The actual implementation of `el-patch-template', accepts the
+same arguments but quoted."
+  (let* ((definition (or (el-patch--locate
+                          (car (el-patch--resolve keyword-name nil)))
+                         (error "Cannot find definition for `%s'"
+                                (cadr keyword-name))))
+         (ptemplates (mapcar
+                      (lambda (template)
+                        (list :template template
+                              :old (el-patch-template--resolve template)
+                              :matched nil))
+                      templates))
+         (patch (prog1 (el-patch-template--apply definition ptemplates)
+                  (cl-dolist (ptemplate ptemplates)
+                    (unless (plist-get ptemplate :matched)
+                      (error "At least one template did \
+not match any form"))))))
+    ;; NOTE: Unfortunately `el-patch-deftype-alist' doesn't save the
+    ;; macro name so we have to assume that it is `el-patch-*'
+    (cons (intern (format "el-patch-%S"
+                          (car patch))) ;; should be an el-patch-*
+          (append (cdr keyword-name)
+                  (cddr patch)))))
+
+(defmacro el-patch-template (keyword-name &rest templates)
+  "KEYWORD-NAME is cons whose car is a type which can be any type
+from `el-patch-deftype-alist' and the cdr is the name of the form
+to be patched. Looks for all forms which match a template in
+TEMPLATES and processes them by matching all `...' forms against
+the souce code of the form, while keeping the `el-patch-*'
+directives. Returns an `el-patch-*' definition.
+
+A template must match exactly one form in the definition. and
+should not match a subform in another template."
+  `(el-patch-template--impl (quote ,keyword-name)
+                            (quote ,templates)))
+
+(provide 'el-patch-template)

--- a/el-patch-template.el
+++ b/el-patch-template.el
@@ -3,11 +3,11 @@
 
 ;; Author: Al Haji-Ali <abdo.haji.ali@gmail.com>
 ;; Created: 1 March 2021
-;; Homepage: http://www.randomoid.com
+;; Homepage: https://github.com/raxod502/el-patch
 ;; Keywords: extensions
 ;; Package-Requires: ((emacs "25"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 0.0.1
+;; Version: 2.3.1
 
 ;;; Commentary:
 ;; `el-patch-template' is an extension of `el-patch' that allows one
@@ -32,8 +32,8 @@
 
 (defun el-patch-template--process-el-patch
     (form template &optional match next-step-fn table)
-  "Processes an el-patch statement. Arguments are the same as
-`el-patch-template--match'. Assume thats template is a cons whose
+  "Process an el-patch statement. Arguments are the same as
+`el-patch-template--match'. Assumes that TEMPLATE is a cons whose
 car is an el-patch directive and throws `not-el-patch' otherwise.
 Upon succesful matching calls `next-step-fn' with MATCH after
 appending it with the matching forms from FORM."
@@ -502,7 +502,7 @@ same arguments but quoted."
 from `el-patch-deftype-alist' and the cdr is the name of the form
 to be patched. Looks for all forms which match a template in
 TEMPLATES and processes them by matching all `...' forms against
-the souce code of the form, while keeping the `el-patch-*'
+the source code of the form, while keeping the `el-patch-*'
 directives. Returns an `el-patch-*' definition.
 
 A template must match exactly one form in the definition. and
@@ -511,3 +511,9 @@ should not match a subform in another template."
                             (quote ,templates)))
 
 (provide 'el-patch-template)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
+;;; el-patch-template.el ends here

--- a/el-patch-template.el
+++ b/el-patch-template.el
@@ -520,7 +520,7 @@ changed to `el-patch-template--concat'."
                   (apply old-concat args)))))
     (el-patch--resolve forms nil)))
 
-;; Stolen from el-patch
+;; Stolen from el-patch--select
 (defun el-patch--select-template ()
   "Use `completing-read' to select a template.
 Return a list of two elements, the name (a symbol) of the object
@@ -650,7 +650,7 @@ matching are done when the functions `el-patch-eval-template' or
   `(el-patch--define-template (quote ,type-name)
                               (quote ,templates)))
 
-(defmacro el-patch-define-compiletime-template (type-name &rest templates)
+(defmacro el-patch-define-and-eval-template (type-name &rest templates)
   "Define and evaluate an el-patch template.
 
 The meaning of TYPE-NAME and TEMPLATES are the same as
@@ -688,6 +688,7 @@ can be slow, consider byte-compiling."))
                                (car qtype-name)))))
 
 
+;; Stolen from `el-patch-validate'
 ;;;###autoload
 (defun el-patch-validate-template (name type &optional nomsg run-hooks)
   "Validate the template with given NAME and TYPE.
@@ -735,6 +736,7 @@ See also `el-patch-validate-all'."
     (when run-hooks
       (run-hooks 'el-patch-post-validate-hook))))
 
+;; Stolen from `el-patch-validate-all'
 ;;;###autoload
 (defun el-patch-validate-all-templates ()
   "Validate all currently defined patches.
@@ -768,7 +770,8 @@ See `el-patch-validate-template'."
           (message "%s valid, %s invalid"
                    (if (= warning-count (1- template-count))
                        "1 template is"
-                     (format "%d templates are" (- template-count warning-count)))
+                     (format "%d templates are"
+                             (- template-count warning-count)))
                    (if (= warning-count 1)
                        "1 template is"
                      (format "%d templates are" warning-count))))))

--- a/el-patch-template.el
+++ b/el-patch-template.el
@@ -44,6 +44,7 @@
 (require 'el-patch)
 
 ;;;;;; Internal functions and variables:
+;;;###autoload
 (defvar el-patch--templates (make-hash-table :test 'equal)
   "Hash table of templates that have been defined.
 The keys are symbols naming the objects that have been patched.
@@ -172,7 +173,7 @@ TABLE is a hashtable containing the bindings of `el-patch-let'"
                                              ;;"[\0-\377[:nonascii:]]*"
                                              ;; match any
                                              ;; character
-                                             "\\(\\(?:.\\|\n\\)*\\)"
+                                             "\\(\\(?:.\\|\n\\)+\\)"
                                            (regexp-quote x)))
                                        resolved)))
                (match-no 1) split-form)
@@ -415,7 +416,7 @@ match is not possible."
                               (if (and (equal x '...))
                                   ;; match any character
                                   ;;"[\0-\377[:nonascii:]]*"
-                                  "\\(.\\|\n\\)*"
+                                  "\\(.\\|\n\\)+"
                                 (regexp-quote x)))
                             (cdr template)))
      form))
@@ -613,6 +614,7 @@ rather than in compile time."
   :type 'boolean
   :group 'el-patch)
 
+;;;###autoload
 (defun el-patch-insert-template (name type)
   "Resolve a template to an el-patch definition and insert it at point.
 
@@ -623,6 +625,7 @@ being patched; TYPE is a symbol `defun', `defmacro', etc."
   (insert (format "%S"
                   (el-patch--resolve-template name type))))
 
+;;;###autoload
 (defun el-patch-eval-template (name type)
   "Resolve a template to an el-patch definition and evaluate it.
 
@@ -632,6 +635,7 @@ being patched; TYPE is a symbol `defun', `defmacro', etc."
   (interactive (el-patch--select-template))
   (eval (el-patch--resolve-template name type)))
 
+;;;###autoload
 (defmacro el-patch-define-template (type-name &rest templates)
   "Define an el-patch template.
 TYPE-NAME is a list whose first element is a type which can be
@@ -650,6 +654,7 @@ matching are done when the functions `el-patch-eval-template' or
   `(el-patch--define-template (quote ,type-name)
                               (quote ,templates)))
 
+;;;###autoload
 (defmacro el-patch-define-and-eval-template (type-name &rest templates)
   "Define and evaluate an el-patch template.
 

--- a/el-patch.el
+++ b/el-patch.el
@@ -640,12 +640,14 @@ is the Lisp form, read from the buffer at point."
                               ,@body))))
           (defun-buffer (car buffer-point))
           (defun-point (cdr buffer-point)))
-     (and defun-buffer
-          defun-point
-          (with-current-buffer defun-buffer
-            (save-excursion
-              (goto-char defun-point)
-              (read (current-buffer)))))))
+     (prog1 (and defun-buffer
+                 defun-point
+                 (with-current-buffer defun-buffer
+                   (save-excursion
+                     (goto-char defun-point)
+                     (read (current-buffer)))))
+       (when defun-buffer
+         (kill-buffer defun-buffer)))))
 
 (defun el-patch-locate-variable (definition)
   "Return the source code of DEFINITION.


### PR DESCRIPTION
This is an implementation of the ideas in #50. I put it as a pull request to discuss the implementation and how it can be improved/refined.

All the suggested examples by @raxod502 should work. Currently, the only limitation is that `...` does not work as expected inside `el-patch-concat`. In particular, I would expect it to match a substring so that one does not have to write the full string if one wants to replace a single word in a long string. The implementation of such a functionality is not difficult but I wanted to get some feedback before complicating the code further.

Also, currently `el-patch-template` simply returns the patch form rather than yanking it to the kill-ring or executing it. For now, this can be done with

```
(kill-new (format "%S" (el-patch-template ...))
(eval (el-patch-template ...))
```
respectively. (In this instance `...` should be filled. `el-patch-template` is not magic :) ) 

Any feedback on the syntax or my lisp is much appreciated (I am not an expert with lisp).



